### PR TITLE
Fixes exception in '--generate-conf-file'

### DIFF
--- a/infrared/api.py
+++ b/infrared/api.py
@@ -72,6 +72,11 @@ class DefaultInfraredPluginSpec(SpecObject):
                              self.name))
         # perform additional arguments validation for a plugin.
         pargs = self.specification.parse_args(parser)
+
+        # '--generate-conf-file' - Finish execution after creation of conf file
+        if pargs is None:
+            return
+
         nested_args = pargs[0]
         control_args = pargs[1]
         unknown_args = pargs[2]


### PR DESCRIPTION
When '--generate-conf-file' option is given, the program continues
running after the creation of the configuration file instead of
stop the execution process.
RHOSINFRA-306