### PR TITLE
Add os requirements to the core

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,12 @@ netaddr>=0.7.18
 gitpython>=0.6.4
 PyYAML>=3.12
 colorlog>=2.7.0
+
+# support for ansible os_ modules
+# keep that here to avoid duplication in plugins
+openstacksdk==0.9.8
+pytz>=2016.3
+os-client-config==1.13.1
+shade==1.7.0
+requests>=2.9.1
+Babel!=2.3.0,!=2.3.1,!=2.3.2,!=2.3.3,>=1.3


### PR DESCRIPTION
Added os requirements to ensure that ansible will work with os modules in the same way for all the plugins. 