### PR TITLE
Profile manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .venv
 *.egg-info
 .idea/
+.profiles

--- a/infrared.cfg
+++ b/infrared.cfg
@@ -1,0 +1,5 @@
+# todo(obaranov) put defaults and any other infrared properties here
+
+[core]
+profiles_base_folder = .profiles
+plugins_base_folder = plugins

--- a/infrared/api.py
+++ b/infrared/api.py
@@ -1,13 +1,16 @@
-# provides AP Ito run plugins
+# provides API to run plugins
 import argparse
 import logging
 import multiprocessing
 import os
+import sys
 import yaml
 
 from infrared import SHARED_GROUPS
 from infrared.core.inspector.inspector import SpecParser
 from infrared.core.settings import SettingsManager
+from infrared.core.services import CoreServices
+from infrared.core.utils import exceptions
 from infrared.core.utils import logger
 
 LOG = logger.LOG
@@ -46,7 +49,12 @@ class SpecObject(object):
 
 
 class DefaultInfraredPluginSpec(SpecObject):
+    """Infrared plugin specification."""
+
     add_base_groups = True
+
+    ANSIBLE_FOLDERS = ["library", "callbacks", "plugins", "templates"]
+    ANSIBLE_FILES = ["ansible.cfg"]
 
     def __init__(self, plugin):
         self.plugin = plugin
@@ -103,32 +111,69 @@ class DefaultInfraredPluginSpec(SpecObject):
             else:
                 playbook = self.plugin.main_playbook
 
-            inventory = control_args.get('inventory', 'local_hosts')
+            inventory = control_args.get('inventory', 'hosts')
 
-            # try to find file within the plugin folder
-            # TODO(obaranov) probably this is not a good idea.
-            # but it simplifies
-            if not os.path.isfile(inventory):
-                plugin_rel_invnetory = os.path.join(self.plugin.root_dir, inventory)
-                if os.path.isfile(plugin_rel_invnetory):
-                    inventory = plugin_rel_invnetory
-                    LOG.warn("Using inventory file from the plugin folder: %s", inventory)
-            inventory = self.__expand_path(inventory)
+            # copy all the required data to the plugin folder
+            active_profile = CoreServices.profile_manager().get_active_profile()
 
+            if not active_profile:
+                raise exceptions.IRNoActiveProfileFound()
+
+            invnetory_name = self.capture_plugin_to_profile(
+                active_profile, inventory)
+
+            LOG.debug("Inventory file used: %s", invnetory_name)
             proc = multiprocessing.Process(
                 target=self._ansible_worker,
-                args=(self.plugin.root_dir, playbook,),
+                args=(active_profile.path, playbook,),
                 kwargs=dict(
                     module_path=self.plugin.modules_dir,
                     verbose=control_args.get('verbose', None),
                     settings=playbook_settings,
-                    inventory=inventory
+                    inventory=invnetory_name
                 ))
             proc.start()
             proc.join()
             if proc.exitcode:
                 # soemthing wrong happened in child process.
                 exit(proc.exitcode)
+
+    def capture_plugin_to_profile(self, profile, inventory):
+        """
+        Copies a plugin data to the profile folder.
+
+        Returns the profile path and new inventory path.
+        """
+        LOG.debug("Initializing the '%s' profile...", profile.name)
+
+        # clear data from previous run
+        profile.clear_links()
+
+        # get the plugin configured folders
+        folders = []
+        for _, fodlers in self.plugin.folders_config.items():
+            folders.extend(fodlers.split(os.pathsep))
+        folders.extend(self.ANSIBLE_FOLDERS)
+
+        for lib in folders:
+            lib_abs_path = os.path.join(os.path.abspath(
+                self.plugin.root_dir), lib)
+            if os.path.exists(lib_abs_path):
+                profile.link_file(lib_abs_path)
+
+        # ansible cfg can be changes by executor/playbooks.
+        # so keep it copy
+        for plugin_file in self.ANSIBLE_FILES:
+            file_abs_path = os.path.join(
+                os.path.abspath(self.plugin.root_dir), plugin_file)
+            profile.copy_file(file_abs_path)
+
+        # resolve invnetory file
+        # first look in the current dir, then in plugin dir, then in profile dir
+        new_inventory = profile.copy_file(
+            inventory, additional_lookup_dirs=(self.plugin.root_dir, profile.path))
+
+        return new_inventory
 
     @staticmethod
     def _ansible_worker(root_dir, playbook,
@@ -138,20 +183,14 @@ class DefaultInfraredPluginSpec(SpecObject):
         os.chdir(root_dir)
         # import here cause it will init ansible in correct plugin folder.
         from infrared.core import execute
-        execute.ansible_playbook(playbook,
-                                 module_path=module_path,
-                                 verbose=verbose,
-                                 settings=settings,
-                                 inventory=inventory)
-
-    def __expand_path(self, path):
-        """
-        Returns the absolute path or None
-        """
-        res = None
-        if path:
-            res = os.path.abspath(path)
-        return res
+        result = execute.ansible_playbook(playbook,
+                                          module_path=module_path,
+                                          verbose=verbose,
+                                          settings=settings,
+                                          inventory=inventory)
+        # fail when playbook/task failed
+        if result:
+            sys.exit(1)
 
 
 class SpecManager(object):

--- a/infrared/core/services/__init__.py
+++ b/infrared/core/services/__init__.py
@@ -1,0 +1,71 @@
+"""Service locator for the IR services
+
+Stores and resolves all the dependencies for the services.
+"""
+import os
+
+from infrared.core.services import profiles
+from infrared.core.services import plugins
+
+
+class CoreServices(object):
+    """
+    Holds and configures all the required for core services
+    """
+
+    SERVICES = {}
+
+    DEFAULTS = {
+        'profiles_base_folder': '.profiles',
+        'plugins_base_folder': 'plugins'
+    }
+
+    @classmethod
+    def form_defaults(cls):
+        """
+        Configures services using the default settings.
+        """
+        cls._configure(
+            cls.DEFAULTS['profiles_base_folder'],
+            cls.DEFAULTS['plugins_base_folder'])
+
+    @classmethod
+    def from_ini_file(cls, config_file, section='core'):
+        """
+        Reads core configuration and configures all the required services.
+        """
+        import ConfigParser
+        config = ConfigParser.ConfigParser()
+        config.read(config_file)
+
+        profile_dir = os.path.abspath(
+            config.get(section, 'profiles_base_folder'))
+        plugins_folder = os.path.abspath(
+            config.get(section, 'plugins_base_folder'))
+
+        cls._configure(profile_dir, plugins_folder)
+
+    @classmethod
+    def _configure(cls, profile_dir, plugins_dir):
+        cls.SERVICES['profile_manager'] = profiles.ProfileManager(profile_dir)
+        cls.SERVICES['plugins_inspector'] = plugins.PluginsInspector(plugins_dir)
+
+    @classmethod
+    def _get_service(cls, name):
+        if name not in cls.SERVICES:
+            cls.form_defaults()
+        return cls.SERVICES[name]
+
+    @classmethod
+    def profile_manager(cls):
+        """
+        Gets the profile manager
+        """
+        return cls._get_service('profile_manager')
+
+    @classmethod
+    def plugins_inspector(cls):
+        """
+        Gets the profile manager
+        """
+        return cls._get_service('plugins_inspector')

--- a/infrared/core/services/plugins.py
+++ b/infrared/core/services/plugins.py
@@ -101,23 +101,25 @@ class InfraredPlugin(object):
 
 
 class PluginsInspector(object):
-    PLUGINS_FOLDER = './plugins'
     CONFIG_FILE_NAME = 'infrared.cfg'
 
-    @classmethod
-    def get_plugin(cls, name):
-        return next(
-            (plg for plg in cls.iter_plugins() if plg.name == name), None)
+    def __init__(self, plugins_dir):
+        # todo(obaranov) consider that multiple plugin folders can be used
+        # here later.
+        self.plugins_dir = plugins_dir
 
-    @classmethod
-    def iter_plugins(cls):
-        for dirpath, _, _ in os.walk(cls.PLUGINS_FOLDER):
+    def get_plugin(self, name):
+        return next(
+            (plg for plg in self.iter_plugins() if plg.name == name), None)
+
+    def iter_plugins(self):
+        for dirpath, _, _ in os.walk(self.plugins_dir):
             LOG.debug("Trying to load plugin from: '%s'", dirpath)
-            config_path = os.path.join(dirpath, cls.CONFIG_FILE_NAME)
+            config_path = os.path.join(dirpath, self.CONFIG_FILE_NAME)
             if os.path.isfile(config_path):
                 try:
                     yield InfraredPlugin.from_config_file(
-                        dirpath, cls.CONFIG_FILE_NAME)
+                        dirpath, self.CONFIG_FILE_NAME)
                 except Exception as ex:
                     LOG.warn(
                         "Error loading plugin '%s': %s", dirpath, ex.message)

--- a/infrared/core/services/profiles.py
+++ b/infrared/core/services/profiles.py
@@ -1,0 +1,227 @@
+import datetime
+import os
+import shutil
+import time
+
+from infrared.core.utils import exceptions, logger
+
+LOG = logger.LOG
+
+TIME_FORMAT = '%Y-%m-%d_%H-%M-%S'
+
+LOCAL_HOSTS = """[local]
+localhost ansible_connection=local ansible_python_interpreter=python
+"""
+
+class ProfileRegistry(object):
+    """Profile resitry holds the profile variable data
+
+    Registry data needs to be cleaned up prior plugin execution
+    and then link folder agains from the used profile.
+    """
+
+    REGISTRY_FILE_NAME = ".registry"
+
+    def __init__(self, path):
+        self.path = path
+        self.registry_file = os.path.join(path, self.REGISTRY_FILE_NAME)
+
+        # creat file if not present
+        if not os.path.exists(self.registry_file):
+            open(self.registry_file, 'a').close()
+
+    def put(self, file_name):
+        """Puts the file in to the registry."""
+
+        with open(self.registry_file, 'a+') as stream:
+            stream.write(file_name + '\n')
+
+    def pop(self):
+        """Pops the file from registry."""
+
+        with open(self.registry_file) as stream:
+            lines = stream.readlines()
+
+        with open(self.registry_file, 'w') as stream:
+            stream.writelines(lines[1:])
+
+        return lines[0].rstrip('\n') if lines else None
+
+
+class Profile(object):
+    """Holds the information about a profile."""
+
+    def __init__(self, name, path):
+        self.name = name
+        self.path = path
+        self.registy = ProfileRegistry(self.path)
+
+    def create_default_inventory(self, name):
+        """Creates the deafault inventory file in the profile dir.
+
+        Creates also the hosts symlink which points the default inventory file.
+        """
+
+        abs_path = os.path.join(self.path, name)
+        with open(abs_path, 'w') as stream:
+            stream.write(LOCAL_HOSTS)
+
+        # create a 'hosts' link
+        self.link_file(abs_path, dest_name='hosts', add_to_reg=False)
+
+    def clear_links(self):
+        """Clears all the created links."""
+
+        first = self.registy.pop()
+        while first != None:
+            if os.path.islink(first):
+                LOG.debug("Removing link: %s", first)
+                os.unlink(first)
+            first = self.registy.pop()
+
+    def link_file(self, file_path,
+                  dest_name=None, unlink=True, add_to_reg=True):
+        """Creates a link to a file within the profile folder.
+
+        profile/filename -> file_path_on_system
+        """
+        if not dest_name:
+            file_name = os.path.basename(os.path.normpath(file_path))
+        else:
+            file_name = dest_name
+
+        target_path = os.path.join(self.path, file_name)
+
+        if unlink and os.path.islink(target_path):
+            os.unlink(target_path)
+
+        LOG.debug("Creating link: src='%s', dest='%s'", file_path, target_path)
+        os.symlink(file_path, target_path)
+        if add_to_reg:
+            self.registy.put(target_path)
+        return target_path
+
+    def copy_file(self, file_path, additional_lookup_dirs=None):
+        """Copies specified file to the profile folder."""
+
+        dirs = [os.path.curdir]
+        if additional_lookup_dirs is not None:
+            dirs.extend(additional_lookup_dirs)
+
+        target_path = None
+        for additional_dir in dirs:
+            abs_path = os.path.join(additional_dir, file_path)
+            if os.path.isfile(abs_path):
+                target_path = os.path.join(
+                    self.path,
+                    os.path.basename(os.path.normpath(abs_path)))
+                if not os.path.exists(target_path) or not os.path.samefile(abs_path, target_path):
+                    LOG.debug("Copying file: src='%s', dest='%s'",
+                              abs_path,
+                              self.path)
+                    shutil.copy2(abs_path, self.path)
+                break
+        if target_path is None:
+            raise IOError("File not found: {}".format(file_path))
+        return target_path
+
+
+class ProfileManager(object):
+    """Manages all the profiles.
+
+    Profile is a folder which contains all the required file for
+    palybooks executions. Additionaly all the generated files
+    will go to the profile folder.
+
+    At least one profile will be active.
+    """
+
+    def __init__(self, profiles_base_dir):
+        self.profile_dir = profiles_base_dir
+        self.active_file = os.path.join(self.profile_dir, ".active")
+
+    def has_profile(self, name):
+        """Checks if profile is present."""
+
+        path = os.path.join(self.profile_dir, name)
+        return os.path.exists(path)
+
+    def create(self, name=None):
+        """Creates a new profile.
+
+        The default invnetory file (local_hosts) will be aslo created.
+        """
+
+        name = name or "profile_" + datetime.datetime.fromtimestamp(
+            time.time()).strftime(TIME_FORMAT)
+        path = os.path.join(self.profile_dir, name)
+        if os.path.exists(path):
+            raise exceptions.IRProfileExists(profile=name)
+        os.makedirs(path)
+        LOG.debug("Profile {} created in {}".format(name, path))
+        profile = Profile(name, path)
+        profile.create_default_inventory('local_hosts')
+        return profile
+
+    def activate(self, name):
+        """Activates the profile."""
+
+        if self.has_profile(name):
+            with open(self.active_file, 'w') as prf_file:
+                prf_file.write(name)
+            LOG.debug("Activating profile %s in %s",
+                      name,
+                      os.path.join(self.profile_dir, name))
+        else:
+            raise exceptions.IRProfileMissing(profile=name)
+
+    def delete(self, name):
+        """Deactivate and removes the profile."""
+
+        if not self.has_profile(name):
+            raise exceptions.IRProfileMissing(profile=name)
+        else:
+            if self.is_active(name):
+                os.remove(self.active_file)
+            shutil.rmtree(os.path.join(self.profile_dir, name))
+
+    def list(self):
+        """Lists all the existing profiles."""
+
+        # walk returns the basedir as well. need to remove it
+        dirlist = [Profile(os.path.basename(d[0]), d[0]) for d in os.walk(
+            self.profile_dir)][1:]
+        return dirlist
+
+    def get(self, name):
+        """Gets the exisiting profile."""
+
+        return next((profile for profile in self.list()
+                     if profile.name == name), None)
+
+    def get_active_profile(self):
+        """Gets the active profile.
+
+        If active profile is present then return the Profile object.
+        Otherwise returns None
+        """
+
+        if os.path.isfile(self.active_file):
+            with open(self.active_file) as prf_file:
+                active_name = prf_file.read().strip()
+                return self.get(active_name)
+
+    def is_active(self, name):
+        """Checks if profile is active."""
+
+        active = self.get_active_profile()
+        return False if active is None else active.name == name
+
+    def cleanup(self, name):
+        """Removes all the files from the profile folder"""
+
+        was_active = self.is_active(name)
+        self.delete(name)
+        self.create(name)
+        if was_active:
+            self.activate(name)

--- a/infrared/core/utils/exceptions.py
+++ b/infrared/core/utils/exceptions.py
@@ -146,3 +146,53 @@ class SpecParserException(Exception):
     def __init__(self, message, errors):
         super(SpecParserException, self).__init__(message)
         self.errors = errors
+
+
+# profile exceptions
+class IRProfileExists(IRException):
+    def __init__(self, profile):
+        message = "Profile {} already exists".format(profile)
+        super(IRProfileExists, self).__init__(message)
+
+
+class IRProfileMissing(IRException):
+    def __init__(self, profile):
+        message = "Profile {} doesn't exist".format(profile)
+        super(IRProfileMissing, self).__init__(message)
+
+
+class IRProfileUndefined(IRConfigurationException):
+    def __init__(self):
+        message = "'profiles' path undefined in 'infrared.cfg'. If you wish " \
+                  "to use 'profiles' feature, please define it. Use " \
+                  "'infrared.cfg.example as template."
+        super(IRProfileUndefined, self).__init__(message)
+
+
+class IRProfileMissingFile(IRException):
+    def __init__(self, profile, filename):
+        message = "File {} not found in Profile {}".format(filename,
+                                                           profile)
+        super(IRProfileMissingFile, self).__init__(message)
+
+
+class IRDefultProfileException(IRException):
+    def __init__(self):
+        message = "Unable to remove or deactivate default profile"
+        super(IRDefultProfileException, self).__init__(message)
+
+
+class IRProfileIsActive(IRException):
+    def __init__(self, profile):
+        message = "Profile is active: {}".format(profile)
+        super(IRProfileIsActive, self).__init__(message)
+
+
+class IRNoActiveProfileFound(IRException):
+    def __init__(self):
+        message = "There is no active profile found. " \
+                  "You can create and activate profile by" \
+                  " running the following commands: " \
+                  "\n infrared profile create <profile_name>" \
+                  "\n infrared profile activate <profile_name>"
+        super(IRNoActiveProfileFound, self).__init__(message)

--- a/infrared/main.py
+++ b/infrared/main.py
@@ -1,15 +1,85 @@
 import os
-import sys
 import shutil
+import sys
 
 import git
 import pip
-from infrared.core.utils import logger
-from infrared.core.plugins import PluginsInspector
+from tabulate import tabulate
+
 from infrared import api
+from infrared.core.services import CoreServices
+from infrared.core.utils import logger
+
 PLUGIN_SETTINGS = 'plugins/settings.yml'
 
 LOG = logger.LOG
+
+
+class ProfileManagerSpec(api.SpecObject):
+    """
+    THe profile manager CLI.
+    """
+
+    def __init__(self, name, *args, **kwargs):
+        super(ProfileManagerSpec, self).__init__(name, *args, **kwargs)
+        self.profile_manager = None
+
+    def extend_cli(self, root_subparsers):
+        parser_plugin = root_subparsers.add_parser(self.name, **self.kwargs)
+        plugins_subparsers = parser_plugin.add_subparsers(dest="command0")
+
+        # create
+        create_parser = plugins_subparsers.add_parser(
+            'create', help='Creates a new profile')
+        create_parser.add_argument("name", help="Profie name")
+
+        # activate
+        activate_parser = plugins_subparsers.add_parser(
+            'activate', help='Activates a profile')
+        activate_parser.add_argument("name", help="Profie name")
+
+        # list
+        plugins_subparsers.add_parser(
+            'list', help='Lists all the profiles')
+
+        # delete
+        delete_parser = plugins_subparsers.add_parser(
+            'delete', help='Deletes a profile')
+        delete_parser.add_argument("name", help="Profie name")
+
+        # cleanup
+        cleanup_parser = plugins_subparsers.add_parser(
+            'cleanup', help='Removes all the files from profile')
+        cleanup_parser.add_argument("name", help="Profie name")
+
+
+    def spec_handler(self, parser, args):
+        """
+        Handles all the plugin manager commands
+        :param parser: the infrared parser object.
+        :param args: the list of arguments received from cli.
+        """
+        command0 = args.get('command0', '')
+
+        profile_manager = CoreServices.profile_manager()
+        if command0 == 'create':
+            profile = profile_manager.create(args.get('name'))
+            print("Profile has been added")
+        elif command0 == 'activate':
+            profile_manager.activate(args.get('name'))
+            print("Profile has been activated")
+        elif command0 == 'list':
+            profiles = profile_manager.list()
+            print(
+                tabulate([[p.name, profile_manager.is_active(p.name)]
+                         for p in profiles],
+                         headers=("Name", "Is Active"),
+                         tablefmt='orgtbl'))
+        elif command0 == 'delete':
+            profile_manager.delete(args.get('name'))
+            print("Profile has been deleted")
+        elif command0 == 'cleanup':
+            profile_manager.cleanup(args.get('name'))
 
 
 class PluginManagerSpec(api.SpecObject):
@@ -72,7 +142,7 @@ class PluginManagerSpec(api.SpecObject):
 
     def _install_requirements(self, submodule):
         # iter_plugins will go through all the plugins subfolders and check what we have there.
-        for plugin in PluginsInspector.iter_plugins():
+        for plugin in CoreServices.plugins_inspector().iter_plugins():
             if os.path.abspath(plugin.root_dir) == os.path.abspath(submodule.path):
                 requirement_file = os.path.join(plugin.root_dir, "plugin_requirements.txt")
                 if os.path.isfile(requirement_file):
@@ -106,12 +176,20 @@ class PluginManagerSpec(api.SpecObject):
 
 
 def main():
+    # configure core services
+    CoreServices.from_ini_file('infrared.cfg')
+
     specs_manager = api.SpecManager()
     specs_manager.register_spec(PluginManagerSpec(
-        'plugin', help="Plugin management command"))
+        'plugin', description="Plugin management"))
+
+    specs_manager.register_spec(ProfileManagerSpec(
+        'profile', description="Profile manager. " \
+        "Allows to create and use an isolated environement " \
+        "for plugins execution."))
 
     # add all the plugins
-    for plugin in PluginsInspector.iter_plugins():
+    for plugin in CoreServices.plugins_inspector().iter_plugins():
         specs_manager.register_spec(api.DefaultInfraredPluginSpec(plugin))
 
     specs_manager.run_specs()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ netaddr>=0.7.18
 gitpython>=0.6.4
 PyYAML>=3.12
 colorlog>=2.7.0
+tabulate>=0.7.7
 
 # support for ansible os_ modules
 # keep that here to avoid duplication in plugins

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,106 @@
+import os
+
+import py
+import pytest
+
+from infrared.core.services.profiles import ProfileManager
+from infrared.core.utils import exceptions
+
+
+@pytest.fixture(scope="session")
+def profile_manager(tmpdir_factory):
+    """
+    Sets the default profile direcotry to the temporary one.
+    """
+    temp_profile_dir = tmpdir_factory.mktemp('pmtest')
+    return ProfileManager(str(temp_profile_dir))
+
+
+@pytest.fixture()
+def test_profile(profile_manager):
+    """
+    Creates test profile in the temp directory.
+    """
+    name = 'test_profile'
+    yield profile_manager.create(name)
+    if profile_manager.has_profile(name):
+        profile_manager.delete(name)
+
+
+@pytest.mark.parametrize('name', ["test_prof", None])
+def test_pm_profile_create(profile_manager, name):
+    """
+    Verify Profile manager allows to create a new profile.
+    """
+    profile = profile_manager.create(name)
+    assert os.path.isdir(profile.path)
+    if name:
+        assert profile.name == name
+
+
+def test_pm_profile_activate(profile_manager, test_profile):
+    """
+    Verify Profile manager allows to activate a profile.
+    """
+
+    profile_manager.activate(test_profile.name)
+    assert profile_manager.is_active(test_profile.name)
+    profile = profile_manager.get_active_profile()
+    assert profile.name == test_profile.name
+    assert profile.path == test_profile.path
+
+
+def test_pm_profile_activate_negative(profile_manager):
+    """
+    Verify Profile manager allows to activate a profile.
+    """
+
+    with pytest.raises(exceptions.IRProfileMissing):
+        profile_manager.activate("wrong_profile")
+
+
+def test_pm_profile_remove(profile_manager, test_profile):
+    """
+    Verify profile can be removed.
+    """
+    profile_manager.activate(test_profile.name)
+    profile_manager.delete(test_profile.name)
+    assert not profile_manager.is_active(test_profile.name)
+    assert not os.path.exists(test_profile.path)
+
+@pytest.mark.parametrize('inventory_content', ["fake content", ""])
+def test_profile_copy_file(profile_manager, test_profile,
+                           tmpdir, inventory_content):
+    """
+    Verify file can be copied to the profile.
+    """
+
+    myfile = tmpdir.mkdir("ir_dir").join("fake_hosts_file")
+    myfile.write(inventory_content)
+    org_inventory = myfile.strpath
+
+    target_path = test_profile.copy_file(org_inventory)
+    assert target_path == os.path.join(
+        test_profile.path, os.path.basename(org_inventory))
+
+    profile_inventory = py.path.local(target_path)
+    assert profile_inventory.check(file=1)
+    assert inventory_content == profile_inventory.read()
+
+
+@pytest.mark.parametrize('inventory_content', ["fake content",])
+def test_profile_link_file(profile_manager, test_profile,
+                           tmpdir, inventory_content):
+    """
+    Verify profiles allows to add a link to a file.
+    """
+    myfile = tmpdir.mkdir("ir_dir").join("fake_hosts_file")
+    myfile.write(inventory_content)
+    org_inventory = myfile.strpath
+
+    target_path = test_profile.link_file(org_inventory)
+    assert target_path == os.path.join(
+        test_profile.path, os.path.basename(org_inventory))
+    profile_inventory = py.path.local(target_path)
+    assert profile_inventory.islink()
+    assert inventory_content == profile_inventory.read()


### PR DESCRIPTION
Initial implementation of the profile manager.  Profile manager is mandatory and will be used even when profile is not explicitly specified. Usage: 

```
ir profile add myprofile
ir profile activate myprofile
ir provisioner virsh [...] # run regular commands 

# additional commands 
ir profile remove myprofile
ir profile list
```

Profile manager will create links to all the folders of the plugin and copy inventory file there.  Executor will use profile folder as the CWD to run ansible. So no changes are required in playbooks for now. 
Playbooks will be updated and synced with IR1 in the separate patch. 

All the profiles are stored under the <core_repo>/.profile folder. 
